### PR TITLE
Fix: Avoid error when parsing 204 (No-Content) response

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -257,6 +257,10 @@ func (r *Resource) do(method string) (*Resource, error) {
 		r.SetHeader(k, r.Raw.Header.Get(k))
 	}
 
+	if resp.StatusCode == http.StatusNoContent {
+		return r, nil
+	}
+
 	err = json.NewDecoder(resp.Body).Decode(r.Response)
 	if err != nil {
 		return r, err

--- a/resource_test.go
+++ b/resource_test.go
@@ -230,6 +230,25 @@ func TestDoNotDecodeBodyOnErr(t *testing.T) {
 	}
 }
 
+
+func TestDoNotDecodeBodyOnNoContent(t *testing.T) {
+
+	api := Api(testSrv.URL)
+
+	testMux.HandleFunc("/no-content",
+		func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusNoContent)
+		})
+
+	resp := make(map[string]interface{})
+	r, err := api.Id("no-content", &resp).Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, http.StatusNoContent, r.Raw.StatusCode )
+}
+
 func readJson(path string) string {
 	buf, err := ioutil.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
This PR intends to fix an issue, error generated, when handling requests that return a 204 (no-content). 

The code assumes that we always have a body and tries to parse it. 
When receiving a 204, there is no body thus an `EOF` error is generated. 

@kovetskiy 
