### PR TITLE
fix: preserve response body for error handling

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -250,6 +250,11 @@ func (r *Resource) do(method string) (*Resource, error) {
 	}
 
 	if resp.StatusCode >= 400 {
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return r, err
+		}
+		r.Raw.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // replace body with ReadCloser that can be read again
 		return r, nil
 	}
 

--- a/resource_test.go
+++ b/resource_test.go
@@ -2,6 +2,7 @@ package gopencils
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -220,7 +221,7 @@ func TestDoNotDecodeBodyOnErr(t *testing.T) {
 		assert.Equal(t, map[string]interface{}{}, resp,
 			fmt.Sprintf("response should be unparsed: %d", code))
 
-		respData, err := ioutil.ReadAll(r.Raw.Body)
+		respData, err := io.ReadAll(r.Raw.Body)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Problem
Previously, the response body was closed before it could be accessed when `resp.StatusCode >= 400`, causing `http: read on closed response body` errors. This broke the `TestDoNotDecodeBodyOnErr` test, which expected the body to remain readable after the request.

## Solution
- Read the response body into memory before closing it.
- Replace `resp.Body` with a new `io.NopCloser(bytes.NewBuffer(bodyBytes))`, allowing it to be read again.

## Result
- Fixes failure while running `TestDoNotDecodeBodyOnErr` test. 
- Maintains proper cleanup of request as before but now also preserves response body accessibility.
- Ensures error responses remain accessible for debugging and logging.